### PR TITLE
Get repo as zip to workaround git api rate limit and infer subsystems…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,27 +37,53 @@ DATABASE_URL=
 ### Installation & Development
 
 1. Install dependencies: `pnpm install`
-2. Run database migrations: `pnpm prisma migrate dev`
+2. Init database schemas: `pnpm prisma:push`
 3. Start the development server: `pnpm dev`
 
 ## How It Works
 
 ### Repository Analysis
-Users can submit a GitHub repository URL, and the service will:
-- Retrieve file paths and README content
-- Use LLM to intelligently group files into logical subsystems
-- Generate a comprehensive overview of the repository structure
+
+Cubic Wiki offers two analysis modes to generate comprehensive documentation for GitHub repositories:
+
+#### 🔍 Basic Analysis (V1)
+- **Method**: File path and README-based analysis
+- **Process**: 
+  - Retrieves repository file structure and README content
+  - Groups files by top-level directories
+  - Uses LLM to intelligently organize files into logical subsystems
+  - Generates comprehensive overview of repository structure
+- **Advantages**: Fast, cost-effective, suitable for most repositories
+- **Best for**: Quick documentation generation and repositories with clear file organization
+
+#### ✨ Advanced Analysis (V2) - Beta
+- **Method**: Full file content analysis with AI clustering
+- **Process**:
+  - Downloads the entire codebase content
+  - Uses AI to identify and select the most important files (up to 50)
+  - Generates individual file summaries and embeddings
+  - Applies K-means clustering to group related files into subsystems
+  - Creates intelligent file groupings based on semantic similarity
+  - Provides deeper insights into code architecture and patterns
+- **Advantages**: More accurate subsystem identification, better understanding of code relationships
+- **Best for**: Complex repositories, detailed architectural analysis
+- **Note**: Request timeout is 60 seconds, larger repositories may fail to generate
 
 ### Deep Dive Analysis
 For specific subsystems, users can request "Get More Insights" to:
 - Send all relevant files to the LLM for detailed analysis
 - Generate in-depth insights about the subsystem's architecture and functionality
 - Provide recommendations and understanding of the codebase
+- Create Mermaid diagrams to visualize system architecture
 
 ## Features
 
-- **Intelligent File Grouping**: LLM-powered subsystem identification
-- **Comprehensive Summaries**: Detailed analysis of repository structure
-- **Deep Dive Capabilities**: Subsystem-specific insights and recommendations
+- **Dual Analysis Modes**: Choose between fast path-based analysis (V1) or comprehensive content-based analysis (V2)
+- **Intelligent File Grouping**: LLM-powered subsystem identification with semantic clustering
+- **Comprehensive Summaries**: Detailed analysis of repository structure and architecture
+- **Deep Dive Capabilities**: Subsystem-specific insights with Mermaid diagram generation
+- **File Content Analysis**: Advanced V2 mode analyzes actual code content for better accuracy
+- **AI-Powered Clustering**: K-means clustering groups related files based on semantic similarity
+- **Smart File Selection**: Automatically identifies and prioritizes the most important files
 - **Modern Tech Stack**: Built with Next.js 15, TypeScript, and Mantine UI
-- **Scalable Architecture**: Prisma ORM with Supabase backend
+- **Scalable Architecture**: Prisma ORM with Supabase backend and vector embeddings

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.50.0",
     "@tabler/icons-react": "^3.34.0",
     "@tanstack/react-query": "^5.80.10",
+    "jszip": "^3.10.1",
     "mermaid": "^11.7.0",
     "ml-kmeans": "^6.0.0",
     "next": "15.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.80.10
         version: 5.80.10(react@19.1.0)
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       mermaid:
         specifier: ^11.7.0
         version: 11.7.0
@@ -1461,6 +1464,9 @@ packages:
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
 
@@ -2110,6 +2116,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2267,6 +2276,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2308,6 +2320,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
@@ -2345,6 +2360,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -2787,6 +2805,9 @@ packages:
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2867,6 +2888,9 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -2972,6 +2996,9 @@ packages:
     resolution: {integrity: sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3036,6 +3063,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3070,6 +3100,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.2:
     resolution: {integrity: sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==}
@@ -3146,6 +3179,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -3373,6 +3409,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -4809,6 +4848,8 @@ snapshots:
 
   confbox@0.2.2: {}
 
+  core-util-is@1.0.3: {}
+
   cose-base@1.0.3:
     dependencies:
       layout-base: 1.0.2
@@ -5677,6 +5718,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5834,6 +5877,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -5874,6 +5919,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   katex@0.16.22:
     dependencies:
       commander: 8.3.0
@@ -5910,6 +5962,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -6599,6 +6655,8 @@ snapshots:
 
   package-manager-detector@1.3.0: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6674,6 +6732,8 @@ snapshots:
       typescript: 5.8.3
 
   proc-log@5.0.0: {}
+
+  process-nextick-args@2.0.1: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -6781,6 +6841,16 @@ snapshots:
 
   read-cmd-shim@5.0.0: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -6882,6 +6952,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -6922,6 +6994,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.2:
     dependencies:
@@ -7055,6 +7129,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -7308,6 +7386,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
 

--- a/src/app/api/generate-subsystem-summary/route.ts
+++ b/src/app/api/generate-subsystem-summary/route.ts
@@ -1,41 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Octokit } from "octokit";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { generateSubsystemSummaryFromFiles } from "@/lib/llm";
+import { getFileContent } from "@/lib/github-utils";
 
 // Zod schema for safety
 const bodySchema = z.object({
   subsystemId: z.number(),
 });
-
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
-});
-
-const getFileContent = async (repoUrl: string, filePath: string) => {
-  try {
-    const response = await octokit.rest.repos.getContent({
-      owner: repoUrl.split("/")[3],
-      repo: repoUrl.split("/")[4],
-      path: filePath,
-    });
-
-    // Handle the case where response.data might be an array
-    if (Array.isArray(response.data)) {
-      return null;
-    }
-
-    if (response.data.type !== "file") {
-      return null;
-    }
-
-    return Buffer.from(response.data.content || "", "base64").toString("utf-8");
-  } catch (error) {
-    console.error(`Failed to fetch file ${filePath}:`, error);
-    return null;
-  }
-};
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/api/generate-v2/route.ts
+++ b/src/app/api/generate-v2/route.ts
@@ -13,9 +13,7 @@ import {
   repoUrlSchema,
   parseGitHubUrl,
   getRepoMetadata,
-  getRepoTree,
   getReadmeContent,
-  getFileContent,
   createWikiPageData,
   getFileFromRepoZip,
 } from "@/lib/github-utils";

--- a/src/app/api/generate-v2/route.ts
+++ b/src/app/api/generate-v2/route.ts
@@ -5,6 +5,7 @@ import {
   generateSummaryFromReadme,
   generateFileSummary,
   generateFileEmbedding,
+  generateImportantFiles,
 } from "@/lib/llm";
 import pLimit from "p-limit";
 import { kmeans } from "ml-kmeans";
@@ -16,6 +17,7 @@ import {
   getReadmeContent,
   getFileContent,
   createWikiPageData,
+  getFileFromRepoZip,
 } from "@/lib/github-utils";
 import {
   findExistingWikiPage,
@@ -39,64 +41,65 @@ export async function POST(req: NextRequest) {
     // Get default branch
     const { branch } = await getRepoMetadata(owner, repo);
 
-    // Get repo tree
-    const tree = await getRepoTree(owner, repo, branch);
+    // Get file content from repo zip
+    const fileContents = await getFileFromRepoZip(repoUrl);
 
-    // Use Promise.all to fetch all files concurrently
-    const fileContents = await Promise.all(
-      tree.map(async (file) => {
-        const content = await getFileContent(repoUrl, file.path!);
-        return {
-          path: file.path!,
-          content: content || "",
-        };
-      })
-    );
+    // Filter out the files by the file name
+    const filteredFileContents = fileContents.filter((file) => {
+      if (
+        file.path.startsWith("dist/") ||
+        file.path.endsWith(".lock") ||
+        file.path.includes("package-lock.json") ||
+        file.path.includes("pnpm-lock.yaml") ||
+        file.path.includes("node_modules/") ||
+        file.path.endsWith(".exe") ||
+        file.path.endsWith(".png") ||
+        file.path.endsWith(".jpg") ||
+        file.path.endsWith(".jpeg") ||
+        file.path.endsWith(".gif") ||
+        file.path.endsWith(".svg") ||
+        file.path.endsWith(".ico") ||
+        file.path.endsWith(".webp") ||
+        file.path.endsWith(".mp4") ||
+        file.path.endsWith(".mp3") ||
+        file.path.endsWith(".wav") ||
+        file.path.endsWith(".ogg") ||
+        file.path.endsWith(".flac") ||
+        file.path.endsWith(".webm") ||
+        file.path.endsWith(".mov") ||
+        file.path.endsWith(".zip") ||
+        file.path.endsWith(".tar") ||
+        file.path.endsWith(".gz") ||
+        file.path.endsWith(".bz2") ||
+        file.path.endsWith(".xz") ||
+        file.path.endsWith(".7z") ||
+        file.path.endsWith(".rar") ||
+        file.path.endsWith(".iso")
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+    // Ask LLM to only keep the important files for inferring the subsystems if the file count is more than 50
+    let importantFiles: { path: string; content: string }[] = [];
+    if (filteredFileContents.length > 50) {
+      importantFiles = await generateImportantFiles(filteredFileContents);
+    } else {
+      importantFiles = filteredFileContents;
+    }
 
     // Generate summary, embedding, and save to database for each file
     // Using plimit to limit the number of concurrent requests to 10
     const fileSummaries = await Promise.all(
-      fileContents.map((file) =>
-        limit(() => {
-          // skip noise files or binary files
-          if (
-            file.path.startsWith("dist/") ||
-            file.path.endsWith(".lock") ||
-            file.path.includes("package-lock.json") ||
-            file.path.includes("pnpm-lock.yaml") ||
-            file.path.startsWith("node_modules/") ||
-            file.path.endsWith(".exe") ||
-            file.path.endsWith(".png") ||
-            file.path.endsWith(".jpg") ||
-            file.path.endsWith(".jpeg") ||
-            file.path.endsWith(".gif") ||
-            file.path.endsWith(".svg") ||
-            file.path.endsWith(".ico") ||
-            file.path.endsWith(".webp") ||
-            file.path.endsWith(".mp4") ||
-            file.path.endsWith(".mp3") ||
-            file.path.endsWith(".wav") ||
-            file.path.endsWith(".ogg") ||
-            file.path.endsWith(".flac") ||
-            file.path.endsWith(".webm") ||
-            file.path.endsWith(".mov") ||
-            file.path.endsWith(".zip") ||
-            file.path.endsWith(".tar") ||
-            file.path.endsWith(".gz") ||
-            file.path.endsWith(".bz2") ||
-            file.path.endsWith(".xz") ||
-            file.path.endsWith(".7z") ||
-            file.path.endsWith(".rar") ||
-            file.path.endsWith(".iso")
-          ) {
-            return "";
-          }
-          return generateFileSummary(file.content).catch((err) => {
+      importantFiles.map((file) =>
+        limit(() =>
+          generateFileSummary(file.content).catch((err) => {
             // skip the error, it could be token limit error
             console.error(err);
             return "";
-          });
-        })
+          })
+        )
       )
     );
     const fileEmbedding = await Promise.all(
@@ -118,7 +121,7 @@ export async function POST(req: NextRequest) {
     // Assign each file to the closest cluster
     for (let i = 0; i < fileEmbedding.length; i++) {
       const embedding = fileEmbedding[i];
-      const path = fileContents[i].path;
+      const path = importantFiles[i].path;
       const summary = fileSummaries[i];
       // Which cluster this file belongs to
       const clusterIndex = clustering.clusters[i];
@@ -173,7 +176,7 @@ export async function POST(req: NextRequest) {
         existingWikiPage.id,
         wikiPageData,
         subsystems,
-        fileContents,
+        importantFiles,
         fileSummaries,
         fileEmbedding
       );
@@ -187,7 +190,7 @@ export async function POST(req: NextRequest) {
     const wikiPage = await createWikiPageWithFiles(
       wikiPageData,
       subsystems,
-      fileContents,
+      importantFiles,
       fileSummaries,
       fileEmbedding
     );

--- a/src/components/repo-input/repo-input.tsx
+++ b/src/components/repo-input/repo-input.tsx
@@ -147,7 +147,7 @@ export default function RepoInput() {
           Beta
         </Badge>
         {/* info icon */}
-        <Tooltip label="Request timeout is 60 seconds, larger repos may failed to generate">
+        <Tooltip label="Request timeout is 60 seconds, larger repos may fail to generate">
           <IconInfoCircle size={22} />
         </Tooltip>
       </Flex>

--- a/src/components/repo-input/repo-input.tsx
+++ b/src/components/repo-input/repo-input.tsx
@@ -9,11 +9,17 @@ import {
   Text,
   TextInput,
   Title,
+  Tooltip,
 } from "@mantine/core";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { showNotification } from "@mantine/notifications";
-import { IconCheck, IconLoader, IconX } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconInfoCircle,
+  IconLoader,
+  IconX,
+} from "@tabler/icons-react";
 
 type FormValues = {
   repoUrl: string;
@@ -134,12 +140,16 @@ export default function RepoInput() {
       <Flex align="center" mb="md">
         <Title order={2}>✨ Generate Wiki</Title>
         <Badge
-          ml="sm"
+          mx="sm"
           variant="gradient"
           gradient={{ from: "blue", to: "cyan", deg: 90 }}
         >
-          Pro
+          Beta
         </Badge>
+        {/* info icon */}
+        <Tooltip label="Request timeout is 60 seconds, larger repos may failed to generate">
+          <IconInfoCircle size={22} />
+        </Tooltip>
       </Flex>
 
       <Text mb="md" c="dimmed">

--- a/src/lib/github-utils.ts
+++ b/src/lib/github-utils.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "octokit";
 import { z } from "zod";
+import JSZip from "jszip";
 
 // Zod schema for safety
 export const repoUrlSchema = z.object({
@@ -9,6 +10,8 @@ export const repoUrlSchema = z.object({
 // Create Octokit client
 export const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
+  // Disable throttling, otherwise the request will hang until the rate limit is reset
+  throttle: { onRateLimit: () => false, onSecondaryRateLimit: () => false },
 });
 
 // GitHub URL parsing utility
@@ -75,6 +78,49 @@ export async function getFileContent(repoUrl: string, filePath: string) {
     console.error(`Failed to fetch file ${filePath}:`, error);
     return null;
   }
+}
+
+// Get file content from repo zip, for better performance and handling rate limit
+export async function getFileFromRepoZip(
+  repoUrl: string
+): Promise<{ path: string; content: string }[]> {
+  const { owner, repo } = parseGitHubUrl(repoUrl);
+
+  // Get default branch
+  const repoMeta = await octokit.rest.repos.get({ owner, repo });
+  const branch = repoMeta.data.default_branch;
+
+  // Download the ZIP archive
+  const response = await octokit.request(
+    `GET /repos/${owner}/${repo}/zipball/${branch}`,
+    {
+      owner,
+      repo,
+      ref: branch,
+      headers: { Accept: "application/vnd.github.v3.raw" },
+    }
+  );
+
+  // Extract ZIP contents
+  const zip = await JSZip.loadAsync(Buffer.from(response.data as any));
+  const files: { path: string; content: string }[] = [];
+
+  for (const fullPath in zip.files) {
+    const entry = zip.files[fullPath];
+    if (entry.dir) continue;
+
+    // Strip GitHub-added root directory (e.g., "owner-repo-sha/")
+    const relativePath = fullPath.substring(fullPath.indexOf("/") + 1);
+
+    try {
+      const content = await entry.async("string");
+      files.push({ path: relativePath, content });
+    } catch {
+      // Skip unreadable (likely binary) files
+    }
+  }
+
+  return files;
 }
 
 // Common wiki page data structure

--- a/src/lib/github-utils.ts
+++ b/src/lib/github-utils.ts
@@ -102,7 +102,7 @@ export async function getFileFromRepoZip(
   );
 
   // Extract ZIP contents
-  const zip = await JSZip.loadAsync(Buffer.from(response.data as any));
+  const zip = await JSZip.loadAsync(Buffer.from(response.data));
   const files: { path: string; content: string }[] = [];
 
   for (const fullPath in zip.files) {


### PR DESCRIPTION
… with fewer files
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched to downloading the repo as a zip file to avoid GitHub API rate limits and improved subsystem inference by selecting only the most important files.

- **Dependencies**
  - Added the jszip package for zip file extraction.

<!-- End of auto-generated description by cubic. -->

